### PR TITLE
Add TypeScript type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
 	"version": "1.0.0",
 	"description": "A modern library to detect OSes and architectures.",
 	"copyright": "Copyright 2021 dangered wolf",
-	"main": "index.js",
+	"main": "./src/PlatformInfo.js",
+	"types": "./src/PlatformInfo.d.ts",
 	"license": "MIT",
 	"bugs": {
 		"url": "https://github.com/dangeredwolf/PlatformInfo/issues"

--- a/src/PlatformInfo.d.ts
+++ b/src/PlatformInfo.d.ts
@@ -1,0 +1,50 @@
+export type OSPlatform =
+	| "windows"
+	| "windows9x"
+	| "windowsPhone"
+	| "android"
+	| "ios"
+	| "mac"
+	| "chromeos"
+	| "linux"
+	| "unknown";
+
+export type Browser =
+	| "chrome"
+	| "firefox"
+	| "ie"
+	| "edge"
+	| "edgeLegacy"
+	| "opera"
+	| "operaPresto"
+	| "safari"
+	| "khtml";
+
+export type Architecture =
+	| "amd64"
+	| "x86"
+	| "arm64"
+	| "arm"
+	| "ppc64"
+	| "ppc"
+	| "ia64";
+
+export declare class PlatformInfo {
+	constructor(customUA: string);
+
+	getOSPlatform(): OSPlatform;
+	getOSVersion(): string | null | undefined;
+	getOSVersionNumber(): number;
+
+	isOSVersionLowerThan(version: any): boolean;
+	isOSVersionHigherThan(version: any): boolean;
+
+	getBrowser(): Browser | undefined;
+	getBrowserVersion(): string | null | undefined;
+	getBrowserVersionNumber(): number;
+
+	isBrowserVersionLowerThan(version: any): boolean;
+	isBrowserVersionHigherThan(version: any): boolean;
+
+	getArchitecture(): Architecture | null | undefined;
+}


### PR DESCRIPTION
I've taken into account all possible code paths when writing these type definitions and due to the way the control flow in some of this library is structured I've had to write some weird types like `Architecture | null | undefined` or `string | null | undefined`. I'm planning to maybe update the way some of these functions are structured to improve readability and give them more consistent return values (preferably all strings all the time) when I have some free time.